### PR TITLE
Fix license and readme

### DIFF
--- a/License
+++ b/License
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2015 Auth0
+Copyright (c) 2015 Auth0, Inc. <support@auth0.com> (http://auth0.com)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,8 +1,19 @@
-php-jwt-example
-===============
+#php-jwt-example
 
 This is an example of how to decode Auth0's generated tokens in PHP.
 
-It uses [firebase/php-jwt](https://github.com/firebase/php-jwt). 
+It uses [firebase/php-jwt](https://github.com/firebase/php-jwt).
 
 You have to Base64 url decode your client secret in order to validate.
+
+## Issue Reporting
+
+If you have found a bug or if you have a feature request, please report them at this repository issues section. Please do not report security vulnerabilities on the public GitHub issue tracker. The [Responsible Disclosure Program](https://auth0.com/whitehat) details the procedure for disclosing security issues.
+
+## Author
+
+[Auth0](auth0.com)
+
+## License
+
+This project is licensed under the MIT license. See the [LICENSE](LICENSE) file for more info.


### PR DESCRIPTION
The license is adjusted to approved contents by @ntotten and the readme
includes the issue reporting, author and license info.

Fixes https://github.com/auth0/php-jwt-example/issues/2
